### PR TITLE
Change channel format in i2s config

### DIFF
--- a/src/Audio/I2S.cpp
+++ b/src/Audio/I2S.cpp
@@ -25,7 +25,7 @@ void I2S::begin() {
 		.mode = i2s_mode_t(I2S_MODE_MASTER | I2S_MODE_RX | I2S_MODE_TX), // Receive, not transfer
 		.sample_rate = SAMPLE_RATE,                         // 16KHz
 		.bits_per_sample = I2S_BITS_PER_SAMPLE_32BIT, // could only get it to work with 32bits
-		.channel_format = I2S_CHANNEL_FMT_ONLY_RIGHT, // although the SEL config should be left, it seems to transmit on right
+		.channel_format = I2S_CHANNEL_FMT_ONLY_LEFT, // although the SEL config should be left, it seems to transmit on right
 		.communication_format = i2s_comm_format_t(I2S_COMM_FORMAT_I2S | I2S_COMM_FORMAT_I2S_MSB),
 		.intr_alloc_flags = 0,     // Interrupt level 1
 		.dma_buf_count = 16,                           // number of buffers


### PR DESCRIPTION
Change channel format in i2s config from I2S_CHANNEL_FMT_ONLY_RIGHT to I2S_CHANNEL_FMT_ONLY_LEFT